### PR TITLE
Added a new client method getDocumentMetrics()

### DIFF
--- a/src/main/java/com/ibm/g11n/pipeline/client/DocumentMetrics.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/DocumentMetrics.java
@@ -1,5 +1,5 @@
 /*  
- * Copyright IBM Corp. 2015
+ * Copyright IBM Corp. 2018
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * <code>BundleMetrics</code> provides read access to translation bundle's
+ * <code>DocumentMetrics</code> provides read access to translation document's
  * metrics information.
  * 
  * @see LanguageMetrics
  * @author Yoshito Umaoka
  */
-public abstract class BundleMetrics {
+public abstract class DocumentMetrics {
 
     /**
      * Returns the translation status metrics by target language.
@@ -40,12 +40,4 @@ public abstract class BundleMetrics {
      * @return The review status metrics by target language.
      */
     public abstract Map<String, ReviewStatusMetrics> getReviewStatusMetricsByLanguage();
-
-    /**
-     * Returns the partner maintained status metrics by target language.
-     * 
-     * @return The partner maintained status metrics by target language.
-     * @deprecated  partner status is no longer used.
-     */
-    public abstract Map<String, Map<String, Integer>> getPartnerStatusMetricsByLanguage();
 }

--- a/src/main/java/com/ibm/g11n/pipeline/client/DocumentType.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/DocumentType.java
@@ -24,9 +24,19 @@ public enum DocumentType {
     /**
      * HTML Document.
      */
-    HTML,
+    HTML("text/html"),
     /**
      * Markdown Document.
      */
-    MD
+    MD("text/markdown");
+
+    private String mediaType;
+
+    DocumentType(String mediaType) {
+        this.mediaType = mediaType;
+    }
+
+    public String getMediaType() {
+        return mediaType;
+    }
 }

--- a/src/main/java/com/ibm/g11n/pipeline/client/ServiceClient.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/ServiceClient.java
@@ -491,7 +491,21 @@ public abstract class ServiceClient {
      * @throws ServiceException when the operation failed.
      */
     public abstract DocumentData getDocumentInfo(DocumentType type, String documentId) throws ServiceException;
-    
+
+    /**
+     * Returns the document's metrics information.
+     * <p>
+     * This operation is only allowed to {@link UserType#ADMINISTRATOR ADMINISTRATOR}
+     * and {@link UserType#TRANSLATOR TRANSLATOR} of the service instance.
+     * 
+     * @param type  The type of document being requested.
+     * @param documentId  The document ID. Must not be null or empty.
+     * @return          The document's metrics information.
+     * @throws ServiceException when the operation failed.
+     * @see LanguageMetrics
+     */
+    public abstract DocumentMetrics getDocumentMetrics(DocumentType type, String documentId) throws ServiceException;
+
     /**
      * Updates the document's configuration.
      * <p>

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/DocumentMetricsImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/DocumentMetricsImpl.java
@@ -1,0 +1,56 @@
+/*  
+ * Copyright IBM Corp. 2018
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ibm.g11n.pipeline.client.impl;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import com.ibm.g11n.pipeline.client.DocumentMetrics;
+import com.ibm.g11n.pipeline.client.ReviewStatusMetrics;
+import com.ibm.g11n.pipeline.client.TranslationStatus;
+
+/**
+ * DocumentMetrics implementation class.
+ * 
+ * @author Yoshito Umaoka
+ */
+public class DocumentMetricsImpl extends DocumentMetrics {
+    private final Map<String, EnumMap<TranslationStatus, Integer>> tsByLang;
+    private final Map<String, ReviewStatusMetrics> rsByLang;
+
+    DocumentMetricsImpl(Map<String, EnumMap<TranslationStatus, Integer>> tsByLang,
+            Map<String, ReviewStatusMetrics> rsByLang) {
+        this.tsByLang = tsByLang;
+        this.rsByLang = rsByLang;
+    }
+
+    @Override
+    public Map<String, EnumMap<TranslationStatus, Integer>> getTranslationStatusMetricsByLanguage() {
+        if (tsByLang == null) {
+            return null;
+        }
+        return Collections.unmodifiableMap(tsByLang);
+    }
+
+    @Override
+    public Map<String, ReviewStatusMetrics> getReviewStatusMetricsByLanguage() {
+        if (rsByLang == null) {
+            return null;
+        }
+        return Collections.unmodifiableMap(rsByLang);
+    }
+}

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
@@ -760,7 +760,7 @@ public class ServiceClientImpl extends ServiceClient {
                         + type.toString().toLowerCase() + "/"
                         + documentId + "/"
                         + language,
-                type == DocumentType.HTML ? "text/html" : "text/plain",
+                type.getMediaType(),
                 fis,
                 ServiceResponse.class,
                 false);

--- a/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
+++ b/src/main/java/com/ibm/g11n/pipeline/client/impl/ServiceClientImpl.java
@@ -64,6 +64,7 @@ import com.ibm.g11n.pipeline.client.BundleDataChangeSet;
 import com.ibm.g11n.pipeline.client.BundleMetrics;
 import com.ibm.g11n.pipeline.client.DocumentData;
 import com.ibm.g11n.pipeline.client.DocumentDataChangeSet;
+import com.ibm.g11n.pipeline.client.DocumentMetrics;
 import com.ibm.g11n.pipeline.client.DocumentTranslationRequestData;
 import com.ibm.g11n.pipeline.client.DocumentTranslationRequestDataChangeSet;
 import com.ibm.g11n.pipeline.client.DocumentType;
@@ -661,7 +662,35 @@ public class ServiceClientImpl extends ServiceClient {
 
         return new DocumentDataImpl(resp.documentData);
     }
-    
+
+    private static class GetDocumentMetricsResponse extends ServiceResponse {
+        private Map<String, EnumMap<TranslationStatus, Integer>> translationStatusMetricsByLanguage;
+        private Map<String, ReviewStatusMetrics> reviewStatusMetricsByLanguage;
+    }
+
+    @Override
+    public DocumentMetrics getDocumentMetrics(DocumentType type, String documentId) throws ServiceException {
+        if (Strings.isNullOrEmpty(documentId)) {
+            throw new IllegalArgumentException("documentId must be specified.");
+        }
+
+        GetDocumentMetricsResponse resp = invokeApiJson(
+                "GET",
+                escapePathSegment(account.getInstanceId()) + "/v2/documents/"
+                    + type.toString().toLowerCase() + "/"
+                    + escapePathSegment(documentId),
+                null,
+                GetDocumentMetricsResponse.class);
+
+        if (resp.getStatus() == Status.ERROR) {
+            throw new ServiceException(resp.getMessage());
+        }
+
+        return new DocumentMetricsImpl(
+                resp.translationStatusMetricsByLanguage,
+                resp.reviewStatusMetricsByLanguage);
+    }
+
     @Override
     public void updateDocument(DocumentType type, String documentId, DocumentDataChangeSet changeSet)
             throws ServiceException {


### PR DESCRIPTION
getDocumentMetrics() is a document counter part of getBundleMetrics.
The new class DocumentMetrics is actually equivalent to existing class
BundleMetrics, but I decided to add it as a new class because 1)
naming, 2) there is a member in BundleMetrics no longer used (marked as
deprecated at this time).

Fixes #35.